### PR TITLE
Fix updating kits failing when going through upsert flow

### DIFF
--- a/apps/web/src/server/services/channels/kits/index.ts
+++ b/apps/web/src/server/services/channels/kits/index.ts
@@ -36,6 +36,17 @@ export const upsertKit = async ({
 		youtubeUrl: kit.youtubeUrl
 	}
 
+	// Remove options from kit when updating so upsert can work correctly
+	if (kit.id) {
+		await prisma.warzoneKit.update({
+			where: { id: kit.id ?? "" },
+			data: {
+				options: {
+					set: []
+				}
+			}
+		})
+	}
 
 	const channel = await prisma.warzoneKit.upsert({
 		where: { id: kit.id ?? "" },


### PR DESCRIPTION
The issue here was that we where connecting kit options in the upsert,
without removing the existing options. This was causing duplicate options
on the specific slot keys.

We'll be looking into updating the db schema to index on

```
kitbase id, option id, and slotkey
```

so that the db will yell at us if something like this happens in the future.