### PR TITLE
bump setup-node version and add caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{matrix.node-version}}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version}}
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install
@@ -33,33 +34,33 @@ jobs:
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:
-            directory: ./apps/web
-            file_name: .env
-            envkey_DB_CONNECTION_STRING: ${{secrets.DB_CONNECTION_STRING}}
-            envkey_DATABASE_URL: ${{secrets.DATABASE_URL}}
-            envkey_NEXT_PUBLIC_GOOGLE_ANALYTICS: ${{secrets.NEXT_PUBLIC_GOOGLE_ANALYTICS}}
-            envkey_NEXT_PUBLIC_API_KEY: ${{secrets.NEXT_PUBLIC_API_KEY}}
-            envkey_NEXT_PUBLIC_FIREBASE_DATABASE_URL: ${{secrets.NEXT_PUBLIC_FIREBASE_DATABASE_URL}}
-            envkey_FIREBASE_PROJECT_ID: ${{secrets.FIREBASE_PROJECT_ID}}
-            envkey_FIREBASE_AUTH_DOMAIN: ${{secrets.FIREBASE_AUTH_DOMAIN}}
-            envkey_FIREBASE_CLIENT_EMAIL: ${{secrets.FIREBASE_CLIENT_EMAIL}}
-            envkey_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.FIREBASE_MESSAGING_SENDER_ID}}
-            envkey_FIREBASE_APP_ID: ${{secrets.FIREBASE_APP_ID}}
-            envkey_FIREBASE_MEASUREMENT_ID: ${{secrets.FIREBASE_MEASUREMENT_ID}}
-            envkey_FIREBASE_COOKIE_SECRET_PREVIOUS: ${{secrets.FIREBASE_COOKIE_SECRET_PREVIOUS}}
-            envkey_FIREBASE_COOKIE_SECRET_CURRENT: ${{secrets.FIREBASE_COOKIE_SECRET_CURRENT}}
-            envkey_TWITCH_CLIENT_ID: ${{secrets.TWITCH_CLIENT_ID}}
-            envkey_TWITCH_SECRET: ${{secrets.TWITCH_SECRET}}
-            envkey_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}}
-            envkey_STRIPE_SECRET_KEY: ${{secrets.STRIPE_SECRET_KEY}}
-            envkey_STRIPE_WEBHOOK_SECRET: ${{secrets.STRIPE_WEBHOOK_SECRET}}
-            envkey_SUBSCRIPTION_PRICE_ID: ${{secrets.SUBSCRIPTION_PRICE_ID}}
-            envkey_MONTHLY_TIP_PRICE_ID: ${{secrets.MONTHLY_TIP_PRICE_ID}}
-            envkey_NEXT_PUBLIC_SOCKET_HOST: ${{secrets.NEXT_PUBLIC_SOCKET_HOST}}
-            envkey_GOOGLE_APPLICATION_CREDENTIALS: ${{secrets.GOOGLE_APPLICATION_CREDENTIALS}}
-            envkey_NEXT_PUBLIC_SENTRY_DSN: ${{secrets.SENTRY_DSN}}
-            envkey_SENTRY_AUTH_TOKEN: ${{secrets.SENTRY_AUTH_TOKEN}}
-            envkey_SENTRY_LOG_LEVEL: debug
+          directory: ./apps/web
+          file_name: .env
+          envkey_DB_CONNECTION_STRING: ${{secrets.DB_CONNECTION_STRING}}
+          envkey_DATABASE_URL: ${{secrets.DATABASE_URL}}
+          envkey_NEXT_PUBLIC_GOOGLE_ANALYTICS: ${{secrets.NEXT_PUBLIC_GOOGLE_ANALYTICS}}
+          envkey_NEXT_PUBLIC_API_KEY: ${{secrets.NEXT_PUBLIC_API_KEY}}
+          envkey_NEXT_PUBLIC_FIREBASE_DATABASE_URL: ${{secrets.NEXT_PUBLIC_FIREBASE_DATABASE_URL}}
+          envkey_FIREBASE_PROJECT_ID: ${{secrets.FIREBASE_PROJECT_ID}}
+          envkey_FIREBASE_AUTH_DOMAIN: ${{secrets.FIREBASE_AUTH_DOMAIN}}
+          envkey_FIREBASE_CLIENT_EMAIL: ${{secrets.FIREBASE_CLIENT_EMAIL}}
+          envkey_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.FIREBASE_MESSAGING_SENDER_ID}}
+          envkey_FIREBASE_APP_ID: ${{secrets.FIREBASE_APP_ID}}
+          envkey_FIREBASE_MEASUREMENT_ID: ${{secrets.FIREBASE_MEASUREMENT_ID}}
+          envkey_FIREBASE_COOKIE_SECRET_PREVIOUS: ${{secrets.FIREBASE_COOKIE_SECRET_PREVIOUS}}
+          envkey_FIREBASE_COOKIE_SECRET_CURRENT: ${{secrets.FIREBASE_COOKIE_SECRET_CURRENT}}
+          envkey_TWITCH_CLIENT_ID: ${{secrets.TWITCH_CLIENT_ID}}
+          envkey_TWITCH_SECRET: ${{secrets.TWITCH_SECRET}}
+          envkey_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}}
+          envkey_STRIPE_SECRET_KEY: ${{secrets.STRIPE_SECRET_KEY}}
+          envkey_STRIPE_WEBHOOK_SECRET: ${{secrets.STRIPE_WEBHOOK_SECRET}}
+          envkey_SUBSCRIPTION_PRICE_ID: ${{secrets.SUBSCRIPTION_PRICE_ID}}
+          envkey_MONTHLY_TIP_PRICE_ID: ${{secrets.MONTHLY_TIP_PRICE_ID}}
+          envkey_NEXT_PUBLIC_SOCKET_HOST: ${{secrets.NEXT_PUBLIC_SOCKET_HOST}}
+          envkey_GOOGLE_APPLICATION_CREDENTIALS: ${{secrets.GOOGLE_APPLICATION_CREDENTIALS}}
+          envkey_NEXT_PUBLIC_SENTRY_DSN: ${{secrets.SENTRY_DSN}}
+          envkey_SENTRY_AUTH_TOKEN: ${{secrets.SENTRY_AUTH_TOKEN}}
+          envkey_SENTRY_LOG_LEVEL: debug
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
@@ -100,7 +101,7 @@ jobs:
           username: ${{secrets.DOKKU_SSH_USER}}
           key: "${{ secrets.DOKKU_SSH_PRIVATE_KEY }}"
           script: |
-           dokku git:from-image api ghcr.io/${{github.repository}}/api-${{github.sha}}
+            dokku git:from-image api ghcr.io/${{github.repository}}/api-${{github.sha}}
 
       - name: Trigger web deployment to Digital Ocean
         uses: appleboy/ssh-action@master
@@ -109,4 +110,4 @@ jobs:
           username: ${{secrets.DOKKU_SSH_USER}}
           key: "${{ secrets.DOKKU_SSH_PRIVATE_KEY }}"
           script: |
-           dokku git:from-image web ghcr.io/${{github.repository}}/web-${{github.sha}}
+            dokku git:from-image web ghcr.io/${{github.repository}}/web-${{github.sha}}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,9 +18,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{matrix.node-version}}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node-version}}
+          cache: "yarn"
 
       - name: Install dependencies
         run: yarn install
@@ -33,35 +34,35 @@ jobs:
       - name: Make envfile
         uses: SpicyPizza/create-envfile@v1.3
         with:
-            directory: ./apps/web
-            file_name: .env
-            envkey_NEXT_PUBLIC_ADS_DISABLED: true
-            envkey_NEXT_PUBLIC_ENABLE_SEEDING: true
-            envkey_DB_CONNECTION_STRING: ${{secrets.CI_DB_CONNECTION_STRING}}
-            envkey_DATABASE_URL: ${{secrets.CI_DATABASE_URL}}
-            envkey_NEXT_PUBLIC_GOOGLE_ANALYTICS: ${{secrets.CI_NEXT_PUBLIC_GOOGLE_ANALYTICS}}
-            envkey_NEXT_PUBLIC_API_KEY: ${{secrets.CI_NEXT_PUBLIC_API_KEY}}
-            envkey_NEXT_PUBLIC_FIREBASE_DATABASE_URL: ${{secrets.CI_NEXT_PUBLIC_FIREBASE_DATABASE_URL}}
-            envkey_FIREBASE_PROJECT_ID: ${{secrets.CI_FIREBASE_PROJECT_ID}}
-            envkey_FIREBASE_AUTH_DOMAIN: ${{secrets.CI_FIREBASE_AUTH_DOMAIN}}
-            envkey_FIREBASE_CLIENT_EMAIL: ${{secrets.CI_FIREBASE_CLIENT_EMAIL}}
-            envkey_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.CI_FIREBASE_MESSAGING_SENDER_ID}}
-            envkey_FIREBASE_APP_ID: ${{secrets.CI_FIREBASE_APP_ID}}
-            envkey_FIREBASE_MEASUREMENT_ID: ${{secrets.CI_FIREBASE_MEASUREMENT_ID}}
-            envkey_FIREBASE_COOKIE_SECRET_PREVIOUS: ${{secrets.CI_FIREBASE_COOKIE_SECRET_PREVIOUS}}
-            envkey_FIREBASE_COOKIE_SECRET_CURRENT: ${{secrets.CI_FIREBASE_COOKIE_SECRET_CURRENT}}
-            envkey_TWITCH_CLIENT_ID: ${{secrets.CI_TWITCH_CLIENT_ID}}
-            envkey_TWITCH_SECRET: ${{secrets.CI_TWITCH_SECRET}}
-            envkey_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{secrets.CI_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}}
-            envkey_STRIPE_SECRET_KEY: ${{secrets.CI_STRIPE_SECRET_KEY}}
-            envkey_STRIPE_WEBHOOK_SECRET: ${{secrets.CI_STRIPE_WEBHOOK_SECRET}}
-            envkey_SUBSCRIPTION_PRICE_ID: ${{secrets.CI_SUBSCRIPTION_PRICE_ID}}
-            envkey_MONTHLY_TIP_PRICE_ID: ${{secrets.CI_MONTHLY_TIP_PRICE_ID}}
-            envkey_NEXT_PUBLIC_SOCKET_HOST: ${{secrets.CI_NEXT_PUBLIC_SOCKET_HOST}}
-            envkey_GOOGLE_APPLICATION_CREDENTIALS: ${{secrets.CI_GOOGLE_APPLICATION_CREDENTIALS}}
-            envkey_NEXT_PUBLIC_SENTRY_DSN: ${{secrets.SENTRY_DSN}}
-            envkey_SENTRY_AUTH_TOKEN: ${{secrets.SENTRY_AUTH_TOKEN}}
-            envkey_SENTRY_LOG_LEVEL: debug
+          directory: ./apps/web
+          file_name: .env
+          envkey_NEXT_PUBLIC_ADS_DISABLED: true
+          envkey_NEXT_PUBLIC_ENABLE_SEEDING: true
+          envkey_DB_CONNECTION_STRING: ${{secrets.CI_DB_CONNECTION_STRING}}
+          envkey_DATABASE_URL: ${{secrets.CI_DATABASE_URL}}
+          envkey_NEXT_PUBLIC_GOOGLE_ANALYTICS: ${{secrets.CI_NEXT_PUBLIC_GOOGLE_ANALYTICS}}
+          envkey_NEXT_PUBLIC_API_KEY: ${{secrets.CI_NEXT_PUBLIC_API_KEY}}
+          envkey_NEXT_PUBLIC_FIREBASE_DATABASE_URL: ${{secrets.CI_NEXT_PUBLIC_FIREBASE_DATABASE_URL}}
+          envkey_FIREBASE_PROJECT_ID: ${{secrets.CI_FIREBASE_PROJECT_ID}}
+          envkey_FIREBASE_AUTH_DOMAIN: ${{secrets.CI_FIREBASE_AUTH_DOMAIN}}
+          envkey_FIREBASE_CLIENT_EMAIL: ${{secrets.CI_FIREBASE_CLIENT_EMAIL}}
+          envkey_FIREBASE_MESSAGING_SENDER_ID: ${{secrets.CI_FIREBASE_MESSAGING_SENDER_ID}}
+          envkey_FIREBASE_APP_ID: ${{secrets.CI_FIREBASE_APP_ID}}
+          envkey_FIREBASE_MEASUREMENT_ID: ${{secrets.CI_FIREBASE_MEASUREMENT_ID}}
+          envkey_FIREBASE_COOKIE_SECRET_PREVIOUS: ${{secrets.CI_FIREBASE_COOKIE_SECRET_PREVIOUS}}
+          envkey_FIREBASE_COOKIE_SECRET_CURRENT: ${{secrets.CI_FIREBASE_COOKIE_SECRET_CURRENT}}
+          envkey_TWITCH_CLIENT_ID: ${{secrets.CI_TWITCH_CLIENT_ID}}
+          envkey_TWITCH_SECRET: ${{secrets.CI_TWITCH_SECRET}}
+          envkey_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{secrets.CI_NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY}}
+          envkey_STRIPE_SECRET_KEY: ${{secrets.CI_STRIPE_SECRET_KEY}}
+          envkey_STRIPE_WEBHOOK_SECRET: ${{secrets.CI_STRIPE_WEBHOOK_SECRET}}
+          envkey_SUBSCRIPTION_PRICE_ID: ${{secrets.CI_SUBSCRIPTION_PRICE_ID}}
+          envkey_MONTHLY_TIP_PRICE_ID: ${{secrets.CI_MONTHLY_TIP_PRICE_ID}}
+          envkey_NEXT_PUBLIC_SOCKET_HOST: ${{secrets.CI_NEXT_PUBLIC_SOCKET_HOST}}
+          envkey_GOOGLE_APPLICATION_CREDENTIALS: ${{secrets.CI_GOOGLE_APPLICATION_CREDENTIALS}}
+          envkey_NEXT_PUBLIC_SENTRY_DSN: ${{secrets.SENTRY_DSN}}
+          envkey_SENTRY_AUTH_TOKEN: ${{secrets.SENTRY_AUTH_TOKEN}}
+          envkey_SENTRY_LOG_LEVEL: debug
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1


### PR DESCRIPTION
bump `setup-node` version to have supported built-in yarn caching. This feature was added in v3 and is based off of this repo: https://github.com/c-hive/gha-yarn-cache

this is for #375