### PR TITLE
Separated warzone from admin page.

### DIFF
--- a/apps/web/src/pages/admin.page.tsx
+++ b/apps/web/src/pages/admin.page.tsx
@@ -1,72 +1,40 @@
 // import Admin from "@Features/Admin"
-import { WarzoneKitBase, WarzoneKitOption } from "@kittr/prisma"
-import { Button, List, Section } from "@kittr/ui"
-import SVG from "@kittr/ui/src/components/SVG"
-import { ActionIcon } from "@mantine/core"
-import { trpc } from "@Server/createHooks"
-import { useState } from "react"
-import { KitBaseForm } from "./admin/KitBaseForm"
 
-const Page = () => {
-	const { data: bases, refetch } = trpc.useQuery(["admin/warzone/kit-bases/list"])
-	const [isCreatingBase, setIsCreatingBase] = useState(false)
-	const [isEditingBase, setIsEditingBase] = useState<
-		|(WarzoneKitBase & {
-				availableOptions: WarzoneKitOption[]
-		  })
-		| null
-	>(null)
+import { Button, Title } from "@kittr/ui"
+import Link from "next/link"
 
-	if (isCreatingBase) {
-		console.log("Game ID", bases![0].gameId)
-		return (
-			<KitBaseForm
-				gameId={bases![0].gameId}
-				onFinished={() => {
-					setIsCreatingBase(false)
-					refetch()
-				}}
-			/>
-		)
+// Hard coded now but for modularity will have to link to db in future
+const GAMEINFO = [
+	{
+		title: "Warzone",
+		link: "/admin/warzone"
+	},
+	{
+		title: "Warzone2",
+		link: "/admin/warzone2"
 	}
+]
 
-	if (isEditingBase) {
-		return (
-			<KitBaseForm
-				gameId={bases![0].gameId}
-				kitBaseId={isEditingBase.id}
-				onFinished={() => {
-					setIsEditingBase(null)
-					refetch()
-				}}
-			/>
-		)
-	}
+const Page = () => (
+	// {
+	// return (
+	<div style={{ margin: "1rem" }}>
+		<div style={{ display: "flex", justifyContent: "space-between" }}>
+			<Title>Games</Title>
 
-	return (
-		<div style={{ margin: "1rem" }}>
-			<Section title="KIT BASES" action={<Button onClick={() => setIsCreatingBase(true)}>Create</Button>}>
-				<List>
-					{(bases || []).map((base: any) => (
-						<List.Item
-							style={{ borderBottom: "1px solid white", padding: "1rem" }}
-							sx={(theme) => ({
-								"&:hover": {
-									backgroundColor: theme.colors.gray[8]
-								}
-							})}
-						>
-							{base.displayName}
-							<ActionIcon radius="lg" size="lg" style={{ float: "right" }} onClick={() => setIsEditingBase(base)}>
-								<SVG.Pencil />
-							</ActionIcon>
-						</List.Item>
-					))}
-				</List>
-			</Section>
-			{/* <Admin /> */}
+			{/* This is a nothing burger placeholder for now.
+			Needs implementation after Warzone2 */}
+			<Button onClick={() => {}}>Create Game</Button>
 		</div>
-	)
-}
 
+		{GAMEINFO.map((game) => (
+			<Link href={game.link}>
+				<Button onClick={() => {}}>{game.title}</Button>
+			</Link>
+		))}
+	</div>
+)
+// )
+// }
 export default Page
+

--- a/apps/web/src/pages/admin/[slug]/index.page.tsx
+++ b/apps/web/src/pages/admin/[slug]/index.page.tsx
@@ -1,0 +1,83 @@
+/* eslint-disable func-call-spacing */
+/* eslint-disable max-len */
+import { useState } from "react"
+import { WarzoneKitBase, WarzoneKitOption } from "@kittr/prisma"
+import { Button, List, Section } from "@kittr/ui"
+import SVG from "@kittr/ui/src/components/SVG"
+import { ActionIcon } from "@mantine/core"
+import { trpc } from "@Server/createHooks"
+import { KitBaseForm } from "../KitBaseForm"
+import Link from "next/link"
+import { useRouter } from "next/router"
+
+const Page = () => {
+	const router = useRouter()
+	// Using slug so that we can reform the KitBase Editors to other games without hard coding new pages for each game.
+	const { slug } = router.query
+	// TODO: Not sure how to handle this type error, need some backend knowledging here.
+	const { data: bases, refetch } = trpc.useQuery([`admin/${slug}/kit-bases/list`])
+	const [isCreatingBase, setIsCreatingBase] = useState(false)
+	const [isEditingBase, setIsEditingBase] = useState<
+		| (WarzoneKitBase & {
+				availableOptions: WarzoneKitOption[]
+		  })
+		| null
+	>(null)
+
+	if (isCreatingBase) {
+		console.log("Game ID", bases![0].gameId)
+		return (
+			<KitBaseForm
+				gameId={bases![0].gameId}
+				onFinished={() => {
+					setIsCreatingBase(false)
+					refetch()
+				}}
+			/>
+		)
+	}
+
+	if (isEditingBase) {
+		return (
+			<KitBaseForm
+				gameId={bases![0].gameId}
+				kitBaseId={isEditingBase.id}
+				onFinished={() => {
+					setIsEditingBase(null)
+					refetch()
+				}}
+			/>
+		)
+	}
+
+	return (
+		<div style={{ margin: "1rem" }}>
+			<Link href="/admin">
+				<Button onClick={() => {}}>Back to Admin Home</Button>
+			</Link>
+			<Section title="KIT BASES" action={<Button onClick={() => setIsCreatingBase(true)}>Create</Button>}>
+				<List>
+					{(bases || []).map((base: any) => (
+						<List.Item
+							style={{ borderBottom: "1px solid white", padding: "1rem" }}
+							sx={(theme) => ({
+								"&:hover": {
+									backgroundColor: theme.colors.gray[8]
+								}
+							})}
+						>
+							{base.displayName}
+							<ActionIcon radius="lg" size="lg" style={{ float: "right" }} onClick={() => setIsEditingBase(base)}>
+								<SVG.Pencil />
+							</ActionIcon>
+						</List.Item>
+					))}
+				</List>
+			</Section>
+			{/* <Admin /> */}
+		</div>
+	)
+}
+
+export default Page
+


### PR DESCRIPTION
Using a slug for modularity since wz and wz2 are so similar for kitbases and for future health of adding new games. Need to implement dashboard routing still. Create game button does not work. Add a "Back to admin home page" button.